### PR TITLE
Fix backport to python2

### DIFF
--- a/normalizr/normalizr.py
+++ b/normalizr/normalizr.py
@@ -1,35 +1,19 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import codecs
 import logging
 import os
 import re
 import string
-import sys
 import unicodedata
-import sys
 
 import normalizr.regex as regex
 
 path = os.path.dirname(__file__)
 
-IS_PY3 = sys.version_info[0] == 3
-
 DEFAULT_NORMALIZATIONS = [
     'remove_extra_whitespaces', 'replace_punctuation', 'replace_symbols', 'remove_stop_words'
 ]
-
-
-def string_translate(s, from_chars='', to_chars='', del_chars=''):
-    if IS_PY3:
-        return s.translate(str.maketrans(from_chars, to_chars, del_chars))
-    else:
-        if isinstance(s, unicode):
-            trans = dict(zip(from_chars, to_chars))
-            trans.update(dict.fromkeys(del_chars))
-            return s.translate(trans)
-        else:
-            return s.translate(string.maketrans(from_chars, to_chars), del_chars)
 
 
 class Normalizr:
@@ -40,12 +24,13 @@ class Normalizr:
         language (string): Language used for normalization.
         lazy_load (boolean): Whether or not lazy load files.
     """
-    __punctuation = string.punctuation
+    __punctuation = set(string.punctuation)
 
     def __init__(self, language='en', lazy_load=False, logger_level=logging.INFO):
         self.__language = language
         self.__logger = self._get_logger(logger_level)
         self.__stop_words = set()
+        self.__characters_regexes = dict()
 
         if not lazy_load:
             self._load_stop_words(language)
@@ -180,7 +165,7 @@ class Normalizr:
         """
         return text.replace('-', replacement)
 
-    def replace_punctuation(self, text, excluded=set(), replacement=''):
+    def replace_punctuation(self, text, excluded=None, replacement=''):
         """
         Remove punctuation from input text or replace them with a string if specified.
 
@@ -194,7 +179,12 @@ class Normalizr:
         Returns:
             The text without punctuation.
         """
-        punct = string_translate(self.__punctuation, del_chars=''.join(excluded))
+        if excluded is None:
+            excluded = set()
+        elif not isinstance(excluded, set):
+            excluded = set(excluded)
+        punct = ''.join(self.__punctuation.difference(excluded))
+
         return self.replace_characters(text, characters=punct, replacement=replacement)
 
     def replace_symbols(self, text, format='NFKD', excluded=set(), replacement=''):
@@ -226,21 +216,17 @@ class Normalizr:
         Returns:
             The text without the given characters.
         """
-        # exit if nothing to replace
         if not characters:
-            # TODO: consider raising a warning here
             return text
 
-        if not replacement:
-            return string_translate(text, del_chars=characters)
+        characters = ''.join(sorted(characters))
+        if characters in self.__characters_regexes:
+            characters_regex = self.__characters_regexes[characters]
+        else:
+            characters_regex = re.compile("[%s]" % re.escape(characters))
+            self.__characters_regexes[characters] = characters_regex
 
-        replacement_char = characters[0]
-
-        if len(characters) > 2:
-            characters = characters[1:]
-            text = string_translate(text, from_chars=characters, to_chars=replacement_char * len(characters))
-
-        return text.replace(replacement_char, replacement)
+        return characters_regex.sub(replacement, text)
 
     def replace_urls(self, text, replacement=''):
         """

--- a/normalizr/regex.py
+++ b/normalizr/regex.py
@@ -1,5 +1,6 @@
 #-*- coding: utf-8 -*-
-# vim:fileencoding=utf-8
+from __future__ import absolute_import, unicode_literals
+
 import re
 
 """

--- a/tests/test_normalizr.py
+++ b/tests/test_normalizr.py
@@ -22,6 +22,9 @@ class TestNormalizr(unittest.TestCase):
     def setUp(self):
         self._normalizr = normalizr.Normalizr()
 
+    def _fail_message(self, test_name):
+        return "failed in sub-test: %s" % test_name
+
     def test_remove_accent_marks(self):
         test_cases = [
             {
@@ -38,7 +41,7 @@ class TestNormalizr(unittest.TestCase):
 
         for test_case in test_cases:
             name, before, after = test_case['name'], test_case['before'], test_case['after']
-            self.assertEqual(self._normalizr.remove_accent_marks(before), after)
+            self.assertEqual(self._normalizr.remove_accent_marks(before), after, msg=self._fail_message(name))
 
     def test_remove_extra_whitespaces(self):
         test_cases = [
@@ -76,7 +79,7 @@ class TestNormalizr(unittest.TestCase):
 
         for test_case in test_cases:
             name, before, after = test_case['name'], test_case['before'], test_case['after']
-            self.assertEqual(self._normalizr.remove_extra_whitespaces(before), after)
+            self.assertEqual(self._normalizr.remove_extra_whitespaces(before), after, msg=self._fail_message(name))
 
     def test_replace_emojis(self):
         test_cases = [
@@ -106,7 +109,7 @@ class TestNormalizr(unittest.TestCase):
         for test_case in test_cases:
             name, before, kwargs, after = \
                 test_case['name'], test_case['before'], test_case.get('kwargs', dict()), test_case['after']
-            self.assertEqual(self._normalizr.replace_emojis(text=before, **kwargs), after)
+            self.assertEqual(self._normalizr.replace_emojis(text=before, **kwargs), after, msg=self._fail_message(name))
 
     def test_replace_hyphens(self):
         test_cases = [
@@ -136,7 +139,7 @@ class TestNormalizr(unittest.TestCase):
         for test_case in test_cases:
             name, before, kwargs, after = \
                 test_case['name'], test_case['before'], test_case.get('kwargs', dict()), test_case['after']
-            self.assertEqual(self._normalizr.replace_hyphens(text=before, **kwargs), after)
+            self.assertEqual(self._normalizr.replace_hyphens(text=before, **kwargs), after, msg=self._fail_message(name))
 
     def test_replace_punctuation(self):
         test_cases = [
@@ -147,19 +150,19 @@ class TestNormalizr(unittest.TestCase):
             },
             {
                 'name': 'no punctuation',
-                'before': "How let the dog out",
-                'after': "How let the dog out"
+                'before': "Who let the dog out",
+                'after': "Who let the dog out"
             },
             {
                 'name': 'question mark default replacement',
-                'before': "How let the dog out?",
-                'after': "How let the dog out"
+                'before': "Who let the dog out?",
+                'after': "Who let the dog out"
             },
             {
                 'name': 'question mark custom replacement',
-                'before': "How let the dog out?",
+                'before': "Who let the dog out?",
                 'kwargs': {'replacement': ' '},
-                'after': "How let the dog out "
+                'after': "Who let the dog out "
             },
             {
                 'name': 'simple sentence default replacement',
@@ -183,7 +186,8 @@ class TestNormalizr(unittest.TestCase):
         for test_case in test_cases:
             name, before, kwargs, after = \
                 test_case['name'], test_case['before'], test_case.get('kwargs', dict()), test_case['after']
-            self.assertEqual(self._normalizr.replace_punctuation(text=before, **kwargs), after)
+            self.assertEqual(self._normalizr.replace_punctuation(text=before, **kwargs), after,
+                             msg=self._fail_message(name))
 
     def test_replace_characters(self):
         test_cases = [
@@ -195,35 +199,35 @@ class TestNormalizr(unittest.TestCase):
             },
             {
                 'name': 'no characters',
-                'before': "How let the dog out?",
+                'before': "Who let the dog out?",
                 'characters': "",
-                'after': "How let the dog out?"
+                'after': "Who let the dog out?"
             },
             {
                 'name': 'vowels',
-                'before': "How let the dog out?",
+                'before': "Who let the dog out?",
                 'characters': "aeiouAEIOU",
-                'after': "Hw lt th dg t?"
+                'after': "Wh lt th dg t?"
             },
             {
                 'name': 'vowels to _',
-                'before': "How let the dog out?",
+                'before': "Who let the dog out?",
                 'characters': "aeiouAEIOU",
                 'kwargs': {'replacement': "_"},
-                'after': "H_w l_t th_ d_g __t?"
+                'after': "Wh_ l_t th_ d_g __t?"
             },
             {
                 'name': 'question mark',
-                'before': "How let the dog out?",
+                'before': "Who let the dog out?",
                 'characters': "?",
-                'after': "How let the dog out?"
+                'after': "Who let the dog out"
             },
             {
                 'name': 'question mark to exclamation mark',
-                'before': "How let the dog out?",
+                'before': "Who let the dog out?",
                 'characters': "?",
                 'kwargs': {'replacement': "!"},
-                'after': "How let the dog out!"
+                'after': "Who let the dog out!"
             },
         ]
 
@@ -231,7 +235,8 @@ class TestNormalizr(unittest.TestCase):
             name, before, characters, kwargs, after = \
                 test_case['name'], test_case['before'], test_case['characters'], test_case.get('kwargs', dict()), \
                 test_case['after']
-            self.assertEqual(self._normalizr.replace_characters(text=before, characters=characters, **kwargs), after)
+            self.assertEqual(self._normalizr.replace_characters(text=before, characters=characters, **kwargs), after,
+                             msg=self._fail_message(name))
 
 
 if __name__ == '__main__':

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -8,10 +8,14 @@ from normalizr import regex
 
 
 def findall_simple(pattern, string):
+    """Wrap re.findall that returns a list of matches, without groups."""
     return [x[0] if isinstance(x, tuple) else x for x in re.findall(pattern=pattern, string=string)]
 
 
 class TestRegex(unittest.TestCase):
+    def _fail_message(self, test_name):
+        return "failed in sub-test: %s" % test_name
+
     def test_find_urls(self):
         test_cases = [
             # (text, list of urls in text)
@@ -29,7 +33,7 @@ class TestRegex(unittest.TestCase):
 
         for test_case in test_cases:
             name, text, urls = test_case['name'], test_case['text'], test_case['urls']
-            self.assertListEqual(findall_simple(regex.URL_REGEX, text), urls)
+            self.assertListEqual(findall_simple(regex.URL_REGEX, text), urls, msg=self._fail_message(name))
 
     def test_find_emails(self):
         test_cases = [
@@ -48,7 +52,7 @@ class TestRegex(unittest.TestCase):
 
         for test_case in test_cases:
             name, text, emails = test_case['name'], test_case['text'], test_case['emails']
-            self.assertListEqual(findall_simple(regex.EMAIL_REGEX, text), emails)
+            self.assertListEqual(findall_simple(regex.EMAIL_REGEX, text), emails, msg=self._fail_message(name))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Should solve issue #16.

The `replace_characters` mechanism was reimplemented, because the regex implementation is easier to backport.

The regex implementation can be further optimized for small texts, by storing compiled regexes.
